### PR TITLE
Add time filter to events page to view past, upcoming, or all events

### DIFF
--- a/app/models/external_event.rb
+++ b/app/models/external_event.rb
@@ -55,6 +55,7 @@ class ExternalEvent < ApplicationRecord
 
   scope :active, -> { where(archived_at: nil) }
   scope :upcoming, -> { where("start_time >= ?", Time.current.beginning_of_day) }
+  scope :past, -> { where("start_time < ?", Time.current.beginning_of_day) }
   scope :by_date_range, ->(start_date, end_date) { where(start_time: start_date.beginning_of_day..end_date.end_of_day) }
   scope :free_only, -> { where(price: [ nil, 0 ]) }
   scope :weekends_only, -> { where("EXTRACT(DOW FROM start_time) IN (0, 6)") } # 0 = Sunday, 6 = Saturday

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -29,6 +29,24 @@
         <h3 class="font-semibold text-gray-900 mb-4">Filters</h3>
         <%= form_with url: events_path, method: :get, class: "space-y-4" do |f| %>
           <div>
+            <%= f.label :time_filter, "Show Events", class: "block text-sm font-medium text-gray-700 mb-2" %>
+            <div class="space-y-2">
+              <div class="flex items-center">
+                <%= f.radio_button :time_filter, "upcoming", { checked: @time_filter == "upcoming", class: "mr-2" } %>
+                <%= f.label :time_filter_upcoming, "Upcoming", class: "text-sm text-gray-700" %>
+              </div>
+              <div class="flex items-center">
+                <%= f.radio_button :time_filter, "past", { checked: @time_filter == "past", class: "mr-2" } %>
+                <%= f.label :time_filter_past, "Past", class: "text-sm text-gray-700" %>
+              </div>
+              <div class="flex items-center">
+                <%= f.radio_button :time_filter, "all", { checked: @time_filter == "all", class: "mr-2" } %>
+                <%= f.label :time_filter_all, "All", class: "text-sm text-gray-700" %>
+              </div>
+            </div>
+          </div>
+
+          <div>
             <%= f.label :start_date, "Start Date", class: "block text-sm font-medium text-gray-700 mb-1" %>
             <%= f.date_field :start_date, value: params[:start_date], class: "w-full px-3 py-2 border border-gray-300 rounded-lg" %>
           </div>
@@ -130,19 +148,19 @@
         </div>
 
         <%# Pagination %>
-        <% if @total_pages > 1 %>
+        <% if @pagination.total_pages > 1 %>
           <div class="flex justify-center items-center space-x-2">
-            <% if @page > 1 %>
-              <%= link_to "← Previous", events_path(page: @page - 1, **params.except(:page, :controller, :action).permit!.to_h),
+            <% if @pagination.page > 1 %>
+              <%= link_to "← Previous", events_path(page: @pagination.page - 1, **params.except(:page, :controller, :action).permit!.to_h),
                   class: "px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition" %>
             <% end %>
 
             <span class="px-4 py-2 text-gray-700">
-              Page <%= @page %> of <%= @total_pages %>
+              Page <%= @pagination.page %> of <%= @pagination.total_pages %>
             </span>
 
-            <% if @page < @total_pages %>
-              <%= link_to "Next →", events_path(page: @page + 1, **params.except(:page, :controller, :action).permit!.to_h),
+            <% if @pagination.page < @pagination.total_pages %>
+              <%= link_to "Next →", events_path(page: @pagination.page + 1, **params.except(:page, :controller, :action).permit!.to_h),
                   class: "px-4 py-2 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition" %>
             <% end %>
           </div>

--- a/spec/models/external_event_spec.rb
+++ b/spec/models/external_event_spec.rb
@@ -99,6 +99,30 @@ RSpec.describe ExternalEvent, type: :model do
       end
     end
 
+    describe ".past" do
+      it "returns events that have already started" do
+        past_event = create(:external_event, :past)
+        upcoming_event = create(:external_event, :upcoming)
+
+        expect(described_class.past).to include(past_event)
+        expect(described_class.past).not_to include(upcoming_event)
+      end
+
+      it "excludes events starting today" do
+        today_event = create(:external_event,
+          start_time: Time.current.end_of_day - 3.hours,
+          end_time: Time.current.end_of_day)
+        expect(described_class.past).not_to include(today_event)
+      end
+
+      it "includes events from yesterday" do
+        yesterday_event = create(:external_event,
+          start_time: 1.day.ago,
+          end_time: 1.day.ago + 2.hours)
+        expect(described_class.past).to include(yesterday_event)
+      end
+    end
+
     describe ".by_date_range" do
       it "returns events within specified date range" do
         start_date = Date.current

--- a/spec/system/event_discovery_spec.rb
+++ b/spec/system/event_discovery_spec.rb
@@ -439,8 +439,8 @@ RSpec.describe "Event Discovery", type: :system do
       let!(:event) do
         create(:external_event,
           title: "Timezone Test Event",
-          start_time: Time.zone.parse("2025-12-26 01:00:00 UTC"),
-          end_time: Time.zone.parse("2025-12-26 06:00:00 UTC"))
+          start_time: Time.zone.parse("2025-12-27 01:00:00 UTC"),
+          end_time: Time.zone.parse("2025-12-27 06:00:00 UTC"))
       end
 
       it "displays start time in user's Pacific timezone on index page" do
@@ -449,7 +449,7 @@ RSpec.describe "Event Discovery", type: :system do
         # Should show 5:00 PM PST (previous day), not 1:00 AM UTC
         expect(page).to have_content("05:00 PM")
         expect(page).to have_content("PST")
-        expect(page).to have_content("Dec 25") # Previous day in PST
+        expect(page).to have_content("Dec 26") # Previous day in PST
       end
 
       it "displays start and end times in user's Pacific timezone on show page" do
@@ -459,7 +459,7 @@ RSpec.describe "Event Discovery", type: :system do
         expect(page).to have_content("05:00 PM PST")
         # Should show 10:00 PM PST, not 6:00 AM UTC
         expect(page).to have_content("10:00 PM PST")
-        expect(page).to have_content("December 25") # Previous day in PST
+        expect(page).to have_content("December 26") # Previous day in PST
       end
     end
 
@@ -471,7 +471,7 @@ RSpec.describe "Event Discovery", type: :system do
         # Event at 8:00 PM EST = 1:00 AM UTC (next day)
         event = create(:external_event,
           title: "Eastern Time Event",
-          start_time: Time.zone.parse("2025-12-26 01:00:00 UTC"))
+          start_time: Time.zone.parse("2025-12-27 01:00:00 UTC"))
 
         visit events_path
 


### PR DESCRIPTION
Users can now filter events on /events by:
- Upcoming (default): Shows future events ordered soonest first
- Past: Shows past events ordered most recent first
- All: Shows all events ordered most recent first

Also refactored pagination into a Pagination struct to improve code quality and reduce instance variables in EventsController.

Added comprehensive tests covering:
- ExternalEvent.past scope (3 tests)
- Time filter behavior and ordering (13 tests)
- Filter persistence across pagination
- Combination with other filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
